### PR TITLE
README 팀원 소개 부분 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,47 +12,23 @@
 ### 🙋‍♂️ 서비스 대상
 
 - 큰 지출을 앞두고 있는 사람
-    - ex) 여행, 지인 선물, 개인적인 물건 구매
+  - ex) 여행, 지인 선물, 개인적인 물건 구매
 - 계획한 일을 실천할때 기록하면서 동기를 얻는 사람
-  ㅇㅇ
+
   <br>
 
 ### 2조 - 지니🧞‍
 
-<div align="center" style="display: flex">
-    <div>
-      <a href="https://github.com/cofreeman">
-          <img src="https://user-images.githubusercontent.com/65614734/234463952-88a0316a-9a7f-46e5-9521-286f1a336fde.png" width="70%">
-      </a>
-      <figcaption>
-          최정우
-      </figcaption>
-    </div>
-    <div>
-    <a href="https://github.com/ffolabear">
-        <img src="https://user-images.githubusercontent.com/65614734/234463967-8c061f78-a3c0-4820-b3fe-860a7619534e.png" width="70%">
-    </a>
-    <figcaption>
-          김태현
-    </figcaption>
-    </div>
-    <div>
-    <a href="https://github.com/FunnyDain">
-        <img src="https://user-images.githubusercontent.com/65614734/234463974-fb7a45f9-78a0-4527-b0dc-ecfa94ed2dfe.png" width="70%">
-    </a>
-    <figcaption>
-          신다인
-    </figcaption>
-    </div>
-    <div>
-    <a href="https://github.com/JYK75">
-        <img src="https://user-images.githubusercontent.com/65614734/234463976-a7153eab-5ba4-4a60-a829-432de60b490d.png" width="70%">
-    </a>
-    <figcaption>
-          김주영
-    </figcaption>
-    </div>
+#### 팀원
+
+<div align=center>
+
+| <img src="https://user-images.githubusercontent.com/65614734/234463952-88a0316a-9a7f-46e5-9521-286f1a336fde.png" width=60%> | <img src="https://user-images.githubusercontent.com/65614734/234463967-8c061f78-a3c0-4820-b3fe-860a7619534e.png" width=60%> | <img src="https://user-images.githubusercontent.com/65614734/234463974-fb7a45f9-78a0-4527-b0dc-ecfa94ed2dfe.png" width=60%> | <img src="https://user-images.githubusercontent.com/65614734/234463976-a7153eab-5ba4-4a60-a829-432de60b490d.png" width=60%>|
+|:-:|:-:|:-:|:-:|
+|[최정우](https://github.com/cofreeman)|[김태현](https://github.com/ffolabear)|[신다인](https://github.com/FunnyDain)|[김주영](https://github.com/JYK75)|
+
 </div>
+
 
 <br>
 
@@ -113,26 +89,26 @@ Related to: #48, #45
 
 - 회원가입 및 로그인 기능(사이트 자체 회원가입)
 - 다른 사용자들이 등록한 챌린지(이하 위시) 열람 가능
-    - 비회원은 상세보기는 불가능
+  - 비회원은 상세보기는 불가능
 - 로그인한 사용자에 한해서 위시 등록 가능
 - 마이페이지 기능
 
 ### 🛠️ 관리자 기능
 
 - 관리자는 악성 유저 및 운영 방침을 미준수한 위시를 블락처리할 수 있음
-    - 적절한 조치를 취한 후 다시 보이게 할 수있음
+  - 적절한 조치를 취한 후 다시 보이게 할 수있음
 
 ### 🍀 위시 관련 기능
 
 - 로그인한 사용자가 마이 위시 페이지에서 자신이 등록한 위시 확인 가능
 - 로그인한 사용자가 새로운 위시 등록 가능
-    - 사용자는 자신의 위시를 `공개` 또는 `비공개`로 설정 가능
-    - 위시에는 `위시제목`, `위시내용`, `상품이름`, `목표금액`, `목표날짜` 정보를 입력할 수 있음
+  - 사용자는 자신의 위시를 `공개` 또는 `비공개`로 설정 가능
+  - 위시에는 `위시제목`, `위시내용`, `상품이름`, `목표금액`, `목표날짜` 정보를 입력할 수 있음
 - 마이 위시에서 상세보기를 클릭한 `위시기록` 의 추가 및 수정과 위시 상세정보 수정 가능
 
 ### ⌛️ 추가 예정 기능
 
-- 위시에 좋아요 기능
+- 위시에 좋아요 기능정
 - 다른 사람과 같이 위시 진행하기 기능
 
 <br>


### PR DESCRIPTION
- 팀원의 프로필 사진을 나란히 나오게 나오게 하는 기능 구현 시도
- 여러 시도 끝에 테이블 작성방법을 활용
- 테이블의 테두리가 여전히 나오는 문제가 있으나 ,

    ```
       1. 이미지를 나란히 나오게 할 것
       2. 이미지 밑에 팀원의 깃허브로 이동할 수 있는 이름을 보여줄것
    ```
   의 두가지 목적은 달성