### PR TITLE
percent로직 수정, basentity상속

### DIFF
--- a/src/main/java/com/project/wish/domain/WishHistory.java
+++ b/src/main/java/com/project/wish/domain/WishHistory.java
@@ -21,7 +21,8 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 @Table(name="wish_history")
-public class WishHistory {
+
+public class WishHistory extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,16 +33,12 @@ public class WishHistory {
     private Wish wish;
     private LocalDateTime historyDatetime;
     private Long amount;
-    private LocalDateTime registerDatetime;
-    private LocalDateTime modifyDatetime;
 
     @Builder
-    public WishHistory(Wish wish, LocalDateTime historyDatetime, Long amount, LocalDateTime registerDatetime,
-        LocalDateTime modifyDatetime) {
+    public WishHistory(Wish wish, LocalDateTime historyDatetime, Long amount) {
         this.wish = wish;
         this.historyDatetime = historyDatetime;
         this.amount = amount;
-        this.registerDatetime = registerDatetime;
-        this.modifyDatetime = modifyDatetime;
+
     }
 }

--- a/src/main/java/com/project/wish/service/WishHistoryService.java
+++ b/src/main/java/com/project/wish/service/WishHistoryService.java
@@ -39,7 +39,6 @@ public interface WishHistoryService {
 //            .wishId(wishHistoryCreateDto.getWishId())
             .historyDatetime(convertSqlDateToLocalDateTime(wishHistoryCreateDto.getHistoryDatetime()))
             .amount(wishHistoryCreateDto.getAmount())
-            .registerDatetime(LocalDateTime.now())
             .build();
     }
 

--- a/src/main/java/com/project/wish/service/WishHistoryServiceImpl.java
+++ b/src/main/java/com/project/wish/service/WishHistoryServiceImpl.java
@@ -51,9 +51,10 @@ public class WishHistoryServiceImpl implements WishHistoryService {
 //        private String cheerUpPhrase;
 
         Wish wish = wishRepository.findById(wishId).orElseThrow();
+//        System.out.println("wish = " + wish);
         List<WishHistory> wishHistories = wish.getWishHistories();
 
-        Long percent = (wishHistories.stream().mapToLong(WishHistory::getAmount).sum()/wish.getGoalAmount())*100;
+        Long percent = (wishHistories.stream().mapToLong(WishHistory::getAmount).sum() * 100)/wish.getGoalAmount();
 
         return WishHistoryRateDto.builder()
                 .wishId(wishId)


### PR DESCRIPTION
WishHistoryServiceImpl에서 percent값을 제대로 받아오지 못한 로직을 수정함, 
BaseEntity를 상속받아 등록일자와 수정일자를 jpa로 구현